### PR TITLE
Fix library target name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ links = "smbclient"
 bindgen = "^0.47.1"
 
 [lib]
-name = "rust-smbclient-sys"
+name = "rust_smbclient_sys"
 path = "src/lib.rs"
 
 


### PR DESCRIPTION
	- Builds fail due to Cargo.toml parsing error, library target names are
	not allowed to have hyphens

cc @cholcombe973 